### PR TITLE
chore: add unit tests for python pkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       - run: |
           cd python
           pip install --upgrade hatch
-          pytest
+          hatch run cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
+
+jobs:
+
+  Test:
+    name: Python ${{ matrix.python-version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          cd python
+          pip install --upgrade hatch
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 *.egg-info/
 .eggs/*
 .ipynb_checkpoints/
+.coverage

--- a/python/README.md
+++ b/python/README.md
@@ -31,7 +31,7 @@ This command will source a python virtual environment with all the necessary dev
 as well as `chromoscope` installed in development mode. You can read more about environments
 in the `hatch` [documentation](https://hatch.pypa.io/latest/environment/).
 
-You can then launch a Jupyter with:
+You can then launch Jupyter:
 
 ```sh
 juptyer lab
@@ -39,7 +39,7 @@ juptyer lab
 
 and navigate to the `notebooks/playground.ipynb` to use the `Viewer`.
 
-All commands are run from the root of the project, from a terminal:
+All development commands are run from the project root, from a terminal:
 
 | Command                | Action                                                              |
 | :--------------------- | :------------------------------------------------------------------ |

--- a/python/README.md
+++ b/python/README.md
@@ -37,7 +37,7 @@ You can then launch a Jupyter with:
 juptyer lab
 ```
 
-and navigate to the `notebooks/playground.ipynb` to use the `Viewer.
+and navigate to the `notebooks/playground.ipynb` to use the `Viewer`.
 
 All commands are run from the root of the project, from a terminal:
 

--- a/python/README.md
+++ b/python/README.md
@@ -8,6 +8,7 @@
 **Table of Contents**
 
 - [Installation](#installation)
+- [Development](#development)
 - [License](#license)
 
 ## Installation
@@ -15,6 +16,38 @@
 ```console
 pip install chromoscope
 ```
+
+## Development
+
+This project uses [`hatch`](https://github.com/pypa/hatch) for development, which can be installed via `pipx`.
+
+To get started, `cd` into this directory and run:
+
+```sh
+hatch shell
+```
+
+This command will source a python virtual environment with all the necessary development dependencies,
+as well as `chromoscope` installed in development mode. You can read more about environments
+in the `hatch` [documentation](https://hatch.pypa.io/latest/environment/).
+
+You can then launch a Jupyter with:
+
+```sh
+juptyer lab
+```
+
+and navigate to the `notebooks/playground.ipynb` to use the `Viewer.
+
+All commands are run from the root of the project, from a terminal:
+
+| Command                | Action                                                              |
+| :--------------------- | :------------------------------------------------------------------ |
+| `hatch run test`       | Run unit tests with `pytest` in latest Python version.              |
+| `hatch run test:test`  | Run unit tests with `pytest` in all target Python versions.         |
+| `hatch version`        | Version the python package. Read more in the [docs](https://hatch.pypa.io/latest/version)|
+| `hatch build`          | Build the sdist and wheels for PyPI. Generates `dist/`              |
+| `hatch publish`        | Publish the package to PyPI. Requires API keys.                     |
 
 ## License
 

--- a/python/src/chromoscope/__init__.py
+++ b/python/src/chromoscope/__init__.py
@@ -1,59 +1,6 @@
 # SPDX-FileCopyrightText: 2023-present Trevor Manz
 #
 # SPDX-License-Identifier: MIT
-from __future__ import annotations
 
-import json
-import pathlib
-
-import servir
-import jinja2
-
-_CHROMOSCOPE_URL = "https://chromoscope.bio"
-_PROVIDER = servir.Provider()
-_RESOURCES = set()
-
-def resolve_file_or_url(x: str):
-    if isinstance(x, str) and (x.startswith("http") or x.startswith("https")):
-        return x
-    path = pathlib.Path(x).resolve()
-    assert path.is_file() and path.exists()
-    resource = _PROVIDER.create(path)
-    _RESOURCES.add(resource)
-    return resource.url
-
-def resolve_config_item(config: dict):
-    reserved_names = ("id", "cancer", "assembly", "note")
-    resolved = {}
-    for k, v in config.items():
-        if k in reserved_names:
-            resolved[k] = v
-        else:
-            resolved[k] = resolve_file_or_url(v)
-    return resolved
-
-def resolve_config(config: dict) -> str:
-    resolved = [resolve_config_item(x) for x in config]
-    resource = _PROVIDER.create(json.dumps(resolved), extension=".json")
-    _RESOURCES.add(resource)
-    return resource.url
-
-
-_TEMPLATE = jinja2.Template("""
-<iframe src="{{ chromoscope_url }}" frameborder="0" allowfullscreen style="width:100%;height:700px;" />
-""")
-
-class Viewer:
-
-    def __init__(self, config_url: str):
-        self._config_url = config_url
-
-    def _repr_mimebundle_(self, **kwargs):
-        url = f"{_CHROMOSCOPE_URL}?external={self._config_url}"
-        return {
-            "text/html": _TEMPLATE.render(chromoscope_url=url)
-        }
-
-    @classmethod
-    def from_config(cls, config: dict):
-        return cls(resolve_config(config))
+from chromoscope.__about__ import __version__
+from chromoscope._viewer import Viewer

--- a/python/src/chromoscope/_viewer.py
+++ b/python/src/chromoscope/_viewer.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import pathlib
+
+import servir
+
+_PROVIDER = servir.Provider()
+_RESOURCES = set()
+
+__all__ = ["Viewer"]
+
+
+def resolve_file_or_url(path_or_url: str | pathlib.Path):
+    """Resolve a file path or URL to a URL.
+
+    Parameters
+    ----------
+    path_or_url : str | pathlib.Path
+        A file path or URL.
+
+    Returns
+    -------
+    str
+        A URL. If `path_or_url` is a URL, it is returned as-is, otherwise
+        a file resource is created and the URL is returned.
+    """
+    normalized = str(path_or_url)
+    if normalized.startswith("http") or normalized.startswith("https"):
+        return normalized
+    path = pathlib.Path(normalized).resolve()
+    assert path.is_file() and path.exists()
+    resource = _PROVIDER.create(path)
+    _RESOURCES.add(resource)
+    return resource.url
+
+
+def resolve_config_item(config: dict):
+    """Resolve a configuration item to use all URLs.
+
+    Parameters
+    ----------
+    config : dict
+        A chromoscope configuration item.
+
+    Returns
+    -------
+    dict
+        A configuration item with all file paths and URLs resolved to URLs.
+    """
+    reserved_names = ("id", "cancer", "assembly", "note")
+    resolved = {}
+    for k, v in config.items():
+        if k in reserved_names:
+            resolved[k] = v
+        else:
+            resolved[k] = resolve_file_or_url(v)
+    return resolved
+
+
+def resolve_config(config: list[dict]) -> str:
+    """Resolve a configuration dictionary to a URL.
+
+    Parameters
+    ----------
+    config : dict
+        A chromoscope configuration.
+
+    Returns
+    -------
+    str
+        A URL to a JSON configuration file.
+    """
+    resolved = [resolve_config_item(x) for x in config]
+    resource = _PROVIDER.create(json.dumps(resolved), extension=".json")
+    _RESOURCES.add(resource)
+    return resource.url
+
+
+def render_html(config_url: str, chromoscope_url: str = "https://chromoscope.bio"):
+    """Render a Chromoscope viewer as HTML.
+
+    Parameters
+    ----------
+    config_url : str
+        A URL to a JSON configuration file.
+    chromoscope_url : str, optional
+        A URL to the Chromoscope website, by default "https://chromoscope.bio"
+
+    Returns
+    -------
+    str
+        An HTML string.
+    """
+    assert config_url.startswith("http") or config_url.startswith("https")
+    assert chromoscope_url.startswith("http") or chromoscope_url.startswith("https")
+    url = f"{chromoscope_url}?external={config_url}"
+    return f"""
+<iframe src="{url}" frameborder="0" allowfullscreen style="width:100%;height:700px;" />
+"""
+
+
+class Viewer:
+    """A Jupyter notebook viewer for Chromoscope."""
+
+    def __init__(
+        self, config_url: str, chromoscope_url: str = "https://chromoscope.bio"
+    ):
+        """Create a new viewer.
+
+        Parameters
+        ----------
+        config_url : str
+            A URL to a JSON configuration file.
+        """
+        self._config_url = config_url
+        self._chromoscope_url = chromoscope_url
+
+    @classmethod
+    def from_config(cls, config: list[dict]):
+        """Create a new viewer from a configuration dictionary.
+
+        Parameters
+        ----------
+        config : dict
+            A chromoscope configuration.
+
+        Returns
+        -------
+        Viewer
+            A new viewer.
+        """
+        return cls(resolve_config(config))
+
+    def _repr_mimebundle_(self, **kwargs):
+        """Render the viewer as an HTML iframe."""
+        return {"text/html": render_html(self._config_url, self._chromoscope_url)}

--- a/python/tests/test_viewer.py
+++ b/python/tests/test_viewer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from chromoscope._viewer import (
+    _PROVIDER,
+    _RESOURCES,
+    Viewer,
+    resolve_config,
+    resolve_config_item,
+    resolve_file_or_url,
+)
+
+
+@pytest.fixture
+def provider():
+    yield _PROVIDER
+    _RESOURCES.clear()
+    _PROVIDER.stop()
+
+@pytest.fixture
+def config(tmp_path: pathlib.Path):
+    local_file = tmp_path / "blah.bedpe"
+    local_file.write_text("test")
+    config_item = {
+        "id": "foo",
+        "cancer": "breast",
+        "assembly": "hg38",
+        "note": "testing 1, 2, 3",
+        "sv": local_file,
+        "cnv" : "https://example.com/cnv.bedpe",
+    }
+    yield [config_item]
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://example.com", "https://example.com"),
+        ("http://example.com", "http://example.com"),
+    ]
+)
+def test_resolves_url_as_is(url: str, expected: str):
+    assert resolve_file_or_url(url) == expected
+
+
+def test_resolves_file_path_to_url(tmp_path: pathlib.Path):
+    file = tmp_path / "test.txt"
+    file.write_text("test")
+    resolved = resolve_file_or_url(file)
+    assert resolved.startswith("http://localhost")
+    assert len(_RESOURCES) == 1
+
+
+def test_resolve_config_item(config: list[dict]):
+    resolved = resolve_config_item(config[0])
+    assert resolved["sv"].startswith("http://localhost")
+    assert resolved.keys() == config[0].keys()
+
+def test_resolve_config(config: list[dict]):
+    config_url = resolve_config(config)
+    assert config_url.startswith("http://localhost")
+    assert config_url.endswith(".json")
+
+
+def test_viewer(config: list[dict]):
+    viewer = Viewer.from_config(config)
+    viewer = Viewer.from_config([{"id": "foo", "sv": "https://example.com"}])
+    assert viewer._config_url.startswith("http://localhost")
+    bundle = viewer._repr_mimebundle_()
+    assert bundle["text/html"]
+


### PR DESCRIPTION
- moves "core" logic into `src/chromoscope/_viewer.py`
- test: add unit tests
- add unit tests to ci
