### PR TITLE
feat: add About popup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,6 +22,96 @@ body {
     background-color: white;
 }
 
+a {
+    text-decoration: none;
+}
+a:visited {
+    color: black;
+}
+a:hover {
+    text-decoration: 3px underline #5bb6ea;
+}
+
+.chromoscope-title {
+    font-weight: bold;
+    margin-right: 20px;
+    text-decoration: none;
+}
+
+.about-modal,
+.about-modal-hidden {
+    z-index: 10001;
+    opacity: 1;
+    position: absolute;
+    left: calc(25%);
+    top: calc(25%);
+    width: 50%;
+    height: 50%;
+    box-shadow: 0 0 15px #0008;
+    background: white;
+    border-radius: 10px;
+    transition: opacity 0.3s ease;
+    padding: 30px;
+}
+.about-modal a {
+    text-decoration: 2px underline #5bb6ea !important;
+}
+.about-modal-disable-button {
+    width: 100%;
+    border-radius: 0px;
+    border: 1px solid grey;
+    height: 30px;
+    font-size: 18px;
+}
+
+.about-modal-hidden,
+.about-modal-container-hidden {
+    visibility: collapse;
+}
+
+.about-modal-container,
+.about-modal-container-hidden {
+    z-index: 10000;
+    background-color: #0006;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+.about-modal-close-button {
+    cursor: pointer;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    background: none;
+    border: none;
+}
+
+.title-doc-link {
+    position: fixed;
+    right: 90px;
+}
+
+.title-about-link {
+    position: fixed;
+    right: 14px;
+    cursor: pointer;
+}
+
+.title-github-link {
+    display: inline-block;
+    position: fixed;
+    right: 240px;
+}
+
+.title-github-link svg {
+    height: 25px;
+    vertical-align: middle;
+    padding-right: 8px;
+    color: black;
+}
+
 .panel-title {
     font-size: 14px;
     font-weight: bold;
@@ -202,8 +292,8 @@ body {
     text-align: center;
     line-height: 30px;
     position: absolute;
-    width: 20px;
-    height: 20px;
+    width: 25px;
+    height: 25px;
     cursor: pointer;
     z-index: 999;
     color: #333333;
@@ -293,6 +383,8 @@ body {
     left: 10px;
     cursor: pointer;
     z-index: 999;
+    stroke: black;
+    stroke-width: 0.5px;
 }
 
 .jump-to-bp-btn {
@@ -348,11 +440,18 @@ body {
 .sample-label {
     position: absolute;
     top: 12px;
-    left: 50px;
+    left: 40px;
     text-shadow: 0px 0px 6px white;
     font-size: 18px;
     z-index: 999;
     background: #ffffff99;
+}
+
+.sample-label small {
+    margin-left: 12px;
+    font-size: 12px;
+    color: gray;
+    margin-right: 10px;
 }
 
 .help-label {
@@ -432,7 +531,7 @@ body {
 .vis-overview-panel .overview-container {
     display: flex;
     flex-wrap: wrap;
-    height: calc(100% - 40px);
+    height: calc(100% - 41px);
     padding: 20px;
     gap: 20px;
     overflow-y: auto;

--- a/src/App.css
+++ b/src/App.css
@@ -34,8 +34,11 @@ a:hover {
 
 .chromoscope-title {
     font-weight: bold;
-    margin-right: 20px;
+    margin-right: 4px;
     text-decoration: none;
+}
+.dimed {
+    color: lightgrey;
 }
 
 .about-modal,
@@ -52,19 +55,21 @@ a:hover {
     border-radius: 10px;
     transition: opacity 0.3s ease;
     padding: 30px;
+    line-height: 2;
+    overflow-y: scroll;
 }
 .about-modal a {
     text-decoration: 2px underline #5bb6ea !important;
 }
 .about-modal-disable-button {
-    width: calc(100% - 60px);
+    width: 100%;
     border-radius: 6px;
     border: 1px solid grey;
     height: 40px;
-    font-size: 18px;
+    font-size: 16px;
     cursor: pointer;
-    position: absolute;
-    bottom: 30px;
+    /* position: absolute; */
+    /* bottom: 30px; */
 }
 
 .about-modal-hidden,
@@ -91,9 +96,16 @@ a:hover {
     border: none;
 }
 
-.title-doc-link {
+.title-github-link {
+    display: inline-block;
     position: fixed;
-    right: 90px;
+    right: 285px;
+}
+
+.title-doc-link {
+    display: inline-block;
+    position: fixed;
+    right: 110px;
 }
 
 .title-about-link {
@@ -102,13 +114,9 @@ a:hover {
     cursor: pointer;
 }
 
-.title-github-link {
-    display: inline-block;
-    position: fixed;
-    right: 240px;
-}
-
-.title-github-link svg {
+.title-github-link svg,
+.title-doc-link svg,
+.title-about-link svg {
     height: 25px;
     vertical-align: middle;
     padding-right: 8px;
@@ -450,6 +458,9 @@ a:hover {
     background: #ffffff99;
 }
 
+.menu-title svg {
+    vertical-align: middle;
+}
 .sample-label small {
     margin-left: 12px;
     font-size: 12px;
@@ -534,7 +545,7 @@ a:hover {
 .vis-overview-panel .overview-container {
     display: flex;
     flex-wrap: wrap;
-    height: calc(100% - 41px);
+    height: calc(100% - 41px - 20px);
     padding: 20px;
     gap: 20px;
     overflow-y: auto;
@@ -548,6 +559,20 @@ a:hover {
 .overview-container {
     width: calc(100% - 400px - 40px);
     float: left;
+}
+
+.overview-status {
+    background: rgba(210, 210, 210, 0.1);
+    width: calc(100% - 400px);
+    height: 20px;
+    float: left;
+    border-bottom: 1px solid lightgrey;
+    padding: 0px;
+    margin: 0px;
+    color: grey;
+    align-content: middle;
+    display: flex;
+    justify-content: center;
 }
 
 .overview-left {

--- a/src/App.css
+++ b/src/App.css
@@ -57,11 +57,14 @@ a:hover {
     text-decoration: 2px underline #5bb6ea !important;
 }
 .about-modal-disable-button {
-    width: 100%;
-    border-radius: 0px;
+    width: calc(100% - 60px);
+    border-radius: 6px;
     border: 1px solid grey;
-    height: 30px;
+    height: 40px;
     font-size: 18px;
+    cursor: pointer;
+    position: absolute;
+    bottom: 30px;
 }
 
 .about-modal-hidden,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,12 @@ import { EXTERNAL_THUMBNAILS } from './data/stevens-mpnst';
 import CancerSelector from './ui/cancer-selector';
 import HorizontalLine from './ui/horizontal-line';
 import SampleConfigForm from './ui/sample-config-form';
+import { BrowserDatabase } from './browser-log';
 
 const db = new Database();
+const log = new BrowserDatabase();
 
+const DB_DO_NOT_SHOW_ABOUT_BY_DEFAULT = (await log.get())?.doNotShowAboutByDefault ?? false;
 const DATABSE_THUMBNAILS = await db.get();
 const GENERATED_THUMBNAILS = {};
 
@@ -81,6 +84,7 @@ function App(props: RouteComponentProps) {
 
     // interactions
     const [showSamples, setShowSamples] = useState(urlParams.get('showSamples') !== 'false' && !xDomain);
+    const [showAbout, setShowAbout] = useState(!DB_DO_NOT_SHOW_ABOUT_BY_DEFAULT);
     const [thumbnailForceGenerate, setThumbnailForceGenerate] = useState(false);
     const [generateThumbnails, setGenerateThumbnails] = useState(false);
     const [doneGeneratingThumbnails, setDoneGeneratingThumbnails] = useState(false);
@@ -610,7 +614,12 @@ function App(props: RouteComponentProps) {
                     />
                 </svg>
                 <div className="sample-label">
-                    {demo.cancer.charAt(0).toUpperCase() + demo.cancer.slice(1) + ' • ' + demo.id}
+                    <a className="chromoscope-title" href="./">
+                        CHROMOSCOPE
+                    </a>
+                    {/* {demo.cancer.charAt(0).toUpperCase() + demo.cancer.slice(1) + ' • ' + demo.id} */}
+                    {demo.cancer.charAt(0).toUpperCase() + demo.cancer.slice(1)}
+                    <small>{demo.id}</small>
                     <span className="title-btn" onClick={() => gosRef.current?.api.exportPng()}>
                         <svg className="button" viewBox="0 0 16 16">
                             <title>Export Image</title>
@@ -693,20 +702,6 @@ function App(props: RouteComponentProps) {
                             <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243L6.586 4.672z" />
                         </svg>
                     </span>
-                    <a
-                        className="title-btn"
-                        href="https://chromoscope.bio/docs/"
-                        target="_blank"
-                        style={{ marginLeft: 140 }}
-                        rel="noreferrer"
-                    >
-                        <svg className="button" viewBox="0 0 16 16">
-                            <title>Open Documentation</title>
-                            <path d="M8.646 5.646a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1 0 .708l-2 2a.5.5 0 0 1-.708-.708L10.293 8 8.646 6.354a.5.5 0 0 1 0-.708zm-1.292 0a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0 0 .708l2 2a.5.5 0 0 0 .708-.708L5.707 8l1.647-1.646a.5.5 0 0 0 0-.708z" />
-                            <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2z" />
-                            <path d="M1 5v-.5a.5.5 0 0 1 1 0V5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1zm0 3v-.5a.5.5 0 0 1 1 0V8h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1zm0 3v-.5a.5.5 0 0 1 1 0v.5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1z" />
-                        </svg>
-                    </a>
                     {!isChrome() ? (
                         <a
                             style={{
@@ -720,17 +715,33 @@ function App(props: RouteComponentProps) {
                             ⚠️ Chromoscope is optimized for Google Chrome
                         </a>
                     ) : null}
+                    <a
+                        className="title-github-link"
+                        href="https://github.com/hms-dbmi/chromoscope"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <title>GitHub</title>
+                            <path
+                                fill="currentColor"
+                                d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+                            ></path>
+                        </svg>
+                        GitHub
+                    </a>
+                    <a className="title-doc-link" href="https://chromoscope.bio/docs/" target="_blank" rel="noreferrer">
+                        Documentation
+                    </a>
+                    <a
+                        className="title-about-link"
+                        onClick={() => {
+                            setShowAbout(true);
+                        }}
+                    >
+                        About
+                    </a>
                 </div>
-                {demo.bam && demo.bai ? (
-                    <div className="help-label">
-                        <span
-                            style={{ border: '1.4px solid gray', borderRadius: 10, padding: '0px 6px', margin: '6px' }}
-                        >
-                            {'?'}
-                        </span>
-                        {'Click on a SV to see alignment around breakpoints'}
-                    </div>
-                ) : null}
                 <div id="vis-panel" className="vis-panel">
                     <div className={'vis-overview-panel ' + (!showSamples ? 'hide' : '')}>
                         <div className="title">
@@ -1082,6 +1093,60 @@ function App(props: RouteComponentProps) {
                         pointerEvents: 'none'
                     }}
                 />
+                <div
+                    className={showAbout ? 'about-modal-container' : 'about-modal-container-hidden'}
+                    onClick={() => setShowAbout(false)}
+                />
+                <div className={showAbout ? 'about-modal' : 'about-modal-hidden'}>
+                    <button className="about-modal-close-button" onClick={() => setShowAbout(false)}>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="30"
+                            height="30"
+                            viewBox="0 0 16 16"
+                            strokeWidth="2"
+                            stroke="none"
+                            fill="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path>
+                        </svg>
+                    </button>
+                    <h2>Chromoscope</h2>
+                    <p>Welcome to the documentation of Chromoscope!</p>
+
+                    <p>
+                        Chromoscope is an interactive visualization tool that supports multiscale and multiform
+                        visualizations. Chromoscope enables users to analyze SVs at multiple scales, using four main
+                        views (multiscale).
+                    </p>
+                    <h4>Learn more about Chromoscope</h4>
+                    <ul>
+                        <li>
+                            GitHub:{' '}
+                            <a href="https://github.com/hms-dbmi/chromoscope" target="_blank" rel="noreferrer">
+                                https://github.com/hms-dbmi/chromoscope
+                            </a>
+                        </li>
+                        <li>
+                            Decomentation:{' '}
+                            <a href="https://chromoscope.bio/docs/" target="_blank" rel="noreferrer">
+                                https://chromoscope.bio/docs/
+                            </a>
+                        </li>
+                        <li>Preprint: TBA </li>
+                    </ul>
+                    <button
+                        className="about-modal-disable-button"
+                        onClick={() => {
+                            log.add(true);
+                            setShowAbout(false);
+                        }}
+                    >
+                        Do not show this information by default
+                    </button>
+                </div>
                 <div
                     className="move-to-top-btn"
                     onClick={() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1117,20 +1117,21 @@ function App(props: RouteComponentProps) {
                     <p>Welcome to the documentation of Chromoscope!</p>
 
                     <p>
-                        Chromoscope is an interactive visualization tool that supports multiscale and multiform
-                        visualizations. Chromoscope enables users to analyze SVs at multiple scales, using four main
-                        views (multiscale).
+                        We developed Chromoscope, an interactive visualization tool that supports <b>multiscale</b> and{' '}
+                        <b>multiform</b> visualizations. Chromoscope enables the user to analyze SVs at multiple scales,
+                        using four main views (multiscale). Moreover, each view uses different visual representations
+                        (multiform) that can facilitate the interpretation for a given level of scale.
                     </p>
                     <h4>Learn more about Chromoscope</h4>
                     <ul>
                         <li>
-                            GitHub:{' '}
+                            <b>GitHub:</b>{' '}
                             <a href="https://github.com/hms-dbmi/chromoscope" target="_blank" rel="noreferrer">
                                 https://github.com/hms-dbmi/chromoscope
                             </a>
                         </li>
                         <li>
-                            Decomentation:{' '}
+                            <b>Decomentation:</b>{' '}
                             <a href="https://chromoscope.bio/docs/" target="_blank" rel="noreferrer">
                                 https://chromoscope.bio/docs/
                             </a>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -617,6 +617,7 @@ function App(props: RouteComponentProps) {
                     <a className="chromoscope-title" href="./">
                         CHROMOSCOPE
                     </a>
+                    <span className="dimed">{' | '}</span>
                     {/* {demo.cancer.charAt(0).toUpperCase() + demo.cancer.slice(1) + ' • ' + demo.id} */}
                     {demo.cancer.charAt(0).toUpperCase() + demo.cancer.slice(1)}
                     <small>{demo.id}</small>
@@ -731,6 +732,15 @@ function App(props: RouteComponentProps) {
                         GitHub
                     </a>
                     <a className="title-doc-link" href="https://chromoscope.bio/docs/" target="_blank" rel="noreferrer">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="20"
+                            height="20"
+                            fill="currentColor"
+                            viewBox="0 0 16 16"
+                        >
+                            <path d="M12 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM5 4h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1zm-.5 2.5A.5.5 0 0 1 5 6h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zM5 8h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1zm0 2h3a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1z" />
+                        </svg>
                         Documentation
                     </a>
                     <a
@@ -739,14 +749,27 @@ function App(props: RouteComponentProps) {
                             setShowAbout(true);
                         }}
                     >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="20"
+                            height="20"
+                            fill="currentColor"
+                            viewBox="0 0 16 16"
+                        >
+                            <path d="M5.933.87a2.89 2.89 0 0 1 4.134 0l.622.638.89-.011a2.89 2.89 0 0 1 2.924 2.924l-.01.89.636.622a2.89 2.89 0 0 1 0 4.134l-.637.622.011.89a2.89 2.89 0 0 1-2.924 2.924l-.89-.01-.622.636a2.89 2.89 0 0 1-4.134 0l-.622-.637-.89.011a2.89 2.89 0 0 1-2.924-2.924l.01-.89-.636-.622a2.89 2.89 0 0 1 0-4.134l.637-.622-.011-.89a2.89 2.89 0 0 1 2.924-2.924l.89.01.622-.636zM7.002 11a1 1 0 1 0 2 0 1 1 0 0 0-2 0zm1.602-2.027c.04-.534.198-.815.846-1.26.674-.475 1.05-1.09 1.05-1.986 0-1.325-.92-2.227-2.262-2.227-1.02 0-1.792.492-2.1 1.29A1.71 1.71 0 0 0 6 5.48c0 .393.203.64.545.64.272 0 .455-.147.564-.51.158-.592.525-.915 1.074-.915.61 0 1.03.446 1.03 1.084 0 .563-.208.885-.822 1.325-.619.433-.926.914-.926 1.64v.111c0 .428.208.745.585.745.336 0 .504-.24.554-.627z" />
+                        </svg>
                         About
                     </a>
                 </div>
                 <div id="vis-panel" className="vis-panel">
                     <div className={'vis-overview-panel ' + (!showSamples ? 'hide' : '')}>
-                        <div className="title">
-                            Samples
-                            {` (Total of ${filteredSamples.length})`}
+                        <div
+                            className="title"
+                            onClick={() => {
+                                setShowSamples(false);
+                            }}
+                        >
+                            <b>CHROMOSCOPE</b> <span className="dimed">{' | '}</span> Samples
                             <input
                                 type="text"
                                 className="sample-text-box"
@@ -811,6 +834,7 @@ function App(props: RouteComponentProps) {
                                     }}
                                 />
                             </div>
+                            <div className="overview-status">{`Total of ${filteredSamples.length} samples loaded`}</div>
                             <div className="overview-container">{smallOverviewWrapper}</div>
                         </div>
                     </div>
@@ -1113,11 +1137,14 @@ function App(props: RouteComponentProps) {
                             <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"></path>
                         </svg>
                     </button>
-                    <h2>Chromoscope</h2>
+                    <p>
+                        <b>Chromoscope</b>
+                        <span className="dimed">{' | '}</span>About
+                    </p>
                     <p>Welcome to the documentation of Chromoscope!</p>
 
                     <p>
-                        We developed Chromoscope, an interactive visualization tool that supports <b>multiscale</b> and{' '}
+                        Chromoscope is an interactive visualization tool that supports <b>multiscale</b> and{' '}
                         <b>multiform</b> visualizations. Chromoscope enables the user to analyze SVs at multiple scales,
                         using four main views (multiscale). Moreover, each view uses different visual representations
                         (multiform) that can facilitate the interpretation for a given level of scale.
@@ -1136,7 +1163,9 @@ function App(props: RouteComponentProps) {
                                 https://chromoscope.bio/docs/
                             </a>
                         </li>
-                        <li>Preprint: TBA </li>
+                        <li>
+                            <b>Preprint:</b> TBA{' '}
+                        </li>
                     </ul>
                     <button
                         className="about-modal-disable-button"

--- a/src/browser-log.ts
+++ b/src/browser-log.ts
@@ -1,0 +1,30 @@
+import { openDB } from 'idb';
+
+const DBNAME = 'DB2';
+const STORENAME = 'LOG';
+
+export class BrowserDatabase {
+    db: IDBDatabase;
+
+    async add(doNotShowAboutByDefault: boolean) {
+        const db = await openDB(DBNAME, undefined, {
+            upgrade(db) {
+                db.createObjectStore(STORENAME, { keyPath: 'id' });
+            }
+        });
+        const tx = db.transaction(STORENAME, 'readwrite');
+        const store = tx.objectStore(STORENAME);
+        await store.put({ id: 'log', doNotShowAboutByDefault });
+    }
+
+    async get() {
+        const db = await openDB(DBNAME, undefined, {
+            upgrade(db) {
+                db.createObjectStore(STORENAME, { keyPath: 'id' });
+            }
+        });
+        const tx = db.transaction(STORENAME, 'readonly');
+        const store = tx.objectStore(STORENAME);
+        return store.get('log');
+    }
+}

--- a/src/ui/cancer-selector.tsx
+++ b/src/ui/cancer-selector.tsx
@@ -226,7 +226,7 @@ export default function CancerSelector(props: { onChange: (url: string) => void 
                 <option key={'Not Selected'} value={null}>
                     Not Selected
                 </option>
-                {PCAWG_SAMPLES.map(sample => {
+                {PCAWG_SAMPLES.sort((a, b) => (a.cancer > b.cancer ? 1 : -1)).map(sample => {
                     const str = `${sample.cancer} (${sample.count} samples)`;
                     const configUrl = sample.url.replace('https://chromoscope.bio/?showSamples=true&external=', '');
                     return (

--- a/src/ui/sample-config-form.tsx
+++ b/src/ui/sample-config-form.tsx
@@ -38,6 +38,7 @@ const testOkay = {
 export default function SampleConfigForm(props: { onAdd: (config: ValidSampleConfig) => void }) {
     const { onAdd } = props;
     const [sampleConfig, setSampleConfig] = useState<SampleConfig>({});
+    const [showNewSampleConfig, setShowNewSampleConfig] = useState(false);
     const sampleOkayToAdd = useMemo(() => {
         let okay = true;
         Object.keys(testOkay).map(k => {
@@ -49,12 +50,42 @@ export default function SampleConfigForm(props: { onAdd: (config: ValidSampleCon
     return (
         <div className="menu-container">
             <div className="menu-title">
-                <span className="menu-title">Add New Sample</span>
+                <span
+                    className="menu-title"
+                    onClick={() => {
+                        setShowNewSampleConfig(!showNewSampleConfig);
+                    }}
+                    style={{ cursor: 'pointer', display: 'inline-block' }}
+                >
+                    Add New Sample
+                    {showNewSampleConfig ? (
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            fill="currentColor"
+                            viewBox="0 0 16 16"
+                        >
+                            <path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z" />
+                        </svg>
+                    ) : (
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            fill="currentColor"
+                            viewBox="0 0 16 16"
+                        >
+                            <path d="m3.86 8.753 5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z" />
+                        </svg>
+                    )}
+                </span>
                 <span
                     className="menu-icon"
-                    style={{ float: 'right', marginRight: '40px' }}
+                    style={{ float: 'right', marginRight: '40px', fontWeight: 300 }}
                     onClick={() => window.open('https://chromoscope.bio/docs/#/data-config', '_blank')}
                 >
+                    Document{' '}
                     <svg width={16} height={16} viewBox={ICONS.DOCS.viewBox}>
                         {ICONS.DOCS.path.map(d => (
                             <path key={d} fill="currentColor" d={d} />
@@ -62,7 +93,12 @@ export default function SampleConfigForm(props: { onAdd: (config: ValidSampleCon
                     </svg>
                 </span>
             </div>
-            <div className="sample-config-form">
+            <div
+                className={showNewSampleConfig ? 'sample-config-form' : 'sample-config-form-hidden'}
+                onClick={() => {
+                    showNewSampleConfig ? null : setShowNewSampleConfig(true);
+                }}
+            >
                 <div className="menu-subtitle">Assembly</div>
                 <select
                     className="menu-dropdown"

--- a/src/ui/side-menu.css
+++ b/src/ui/side-menu.css
@@ -22,11 +22,17 @@
     height: 1px;
     border-top: 1px solid lightgrey;
 }
+.sample-config-form-hidden,
 .sample-config-form {
     width: calc(100% - 80px);
     border-radius: 10px;
     background-color: rgb(244, 244, 244);
     padding: 20px;
+}
+.sample-config-form-hidden {
+    height: 0px;
+    cursor: pointer;
+    content-visibility: hidden;
 }
 .menu-button,
 .menu-button-disallowed {


### PR DESCRIPTION
## Updates
- Add About popup that is shown by default on a browser
- Add About, Documentation, Github links much obvious to the header
- Add Chromoscope title to the main views
- Fold "Add New Sample" by default
- Add "Document" label near the Add New Sample
- Sort samples by alphabet order

Fix #108 
Fix #106
Towards #105

cc @ngehlenborg @dominikglodzikhms (any further suggestions are welcomed)

<img width="1392" alt="Screenshot 2023-05-09 at 17 21 09" src="https://github.com/hms-dbmi/chromoscope/assets/9922882/d2fbaa76-6206-4d43-847a-ff2de7e0e96b">
<img width="1392" alt="Screenshot 2023-05-09 at 17 21 18" src="https://github.com/hms-dbmi/chromoscope/assets/9922882/3da40d6a-76bc-4991-ba98-c4606ccc8817">
<img width="1392" alt="Screenshot 2023-05-09 at 17 21 20" src="https://github.com/hms-dbmi/chromoscope/assets/9922882/7de7619a-76a8-48c5-b304-9d8c54115d5a">
