### PR TITLE
feat: make CNV file optional

### DIFF
--- a/docs/docs/loading-data/through-data-config.md
+++ b/docs/docs/loading-data/through-data-config.md
@@ -23,7 +23,7 @@ For each sample, you need to prepare the following information in a JSON object.
 | `cancer` | `string` | Required. Type of a cancer. |
 | `assembly` | `'hg38'` or `'hg19'` | Required. Assembly. |
 | `sv` | `string` | Required. An URL of the SV bedpe file (`.bedpe`). |
-| `cnv` | `string` | Required. An URL of the CNV text file (`.tsv`). |
+| `cnv` | `string` | Optional. An URL of the CNV text file (`.tsv`). |
 | `drivers` | `string` | Optional. An URL of a file that contains drivers (`.tsv` or `.json`). |
 | `vcf` | `string` | Optional. An URL of the point mutation file (`.vcf`). |
 | `vcfIndex` | `string` | Optional. An URL of the point mutation index file (`.tbi`). |

--- a/src/data/samples.ts
+++ b/src/data/samples.ts
@@ -20,7 +20,7 @@ export type SampleType = {
     cancer: string; // cancer type
     assembly: Assembly; // hg19 or 38
     sv: string; // URL of bedpe
-    cnv: string; // URL of txt
+    cnv?: string; // URL of txt
     drivers?: { [k: string]: string | number }[] | string;
     bam?: string;
     bai?: string;

--- a/src/main-spec.ts
+++ b/src/main-spec.ts
@@ -315,9 +315,9 @@ function getOverviewSpec(option: SpecOption): View[] {
                 },
                 tracks.driver(id, driversToTsvUrl(drivers), width, 40, 'top'),
                 tracks.boundary('driver', 'top'),
-                tracks.gain(id, cnv, width, 40, 'top', cnFields),
+                cnv ? [tracks.gain(id, cnv, width, 40, 'top', cnFields)] : [],
                 tracks.boundary('gain', 'top'),
-                tracks.loh(id, cnv, width, 40, 'top', cnFields),
+                cnv ? [tracks.loh(id, cnv, width, 40, 'top', cnFields)] : [],
                 tracks.boundary('loh', 'top'),
                 tracks.sv(id, sv, width, 80, 'top', selectedSvId)
             ]

--- a/src/ui/sample-config-form.tsx
+++ b/src/ui/sample-config-form.tsx
@@ -24,8 +24,8 @@ const testOkay = {
     id: (_: SampleConfig) => _.id,
     cancer: (_: SampleConfig) => _.cancer,
     sv: (_: SampleConfig) => isValidUrl(_.sv),
-    cnv: (_: SampleConfig) => isValidUrl(_.cnv),
     // optional
+    cnv: (_: SampleConfig) => !_.cnv || isValidUrl(_.cnv),
     drivers: (_: SampleConfig) => !_.drivers || isValidUrl(_.drivers),
     vcf: (_: SampleConfig) => !_.vcf || isValidUrl(_.vcf),
     vcfIndex: (_: SampleConfig) => !_.vcfIndex || isValidUrl(_.vcfIndex),
@@ -155,14 +155,13 @@ export default function SampleConfigForm(props: { onAdd: (config: ValidSampleCon
                 />
 
                 <div className="menu-subtitle">
-                    CNV<sup>*</sup> <small>(.txt)</small>
+                    CNV <small>(.txt)</small>
                 </div>
                 {/* <span className="menu-subtitle-right">Required</span> */}
                 <input
                     type="text"
                     className={testOkay.cnv(sampleConfig) ? 'menu-text-input' : 'menu-text-input-invalid'}
                     placeholder="https://..."
-                    required
                     onChange={e => setSampleConfig({ ...sampleConfig, cnv: e.currentTarget.value })}
                     value={sampleConfig.cnv}
                 />


### PR DESCRIPTION
Make the CNV file optional and reflect this in the UI:
- Exclude GAIN and LOH tracks if cnv field is undefined
- Update cnv item in docs
- Update cnv input in the UI (remove red border and update input validation)