### PR TITLE
feat: show REF and ALT in tooltips

### DIFF
--- a/src/track/mutation.ts
+++ b/src/track/mutation.ts
@@ -28,7 +28,9 @@ export default function mutation(
         tooltip: [
             { field: 'DISTPREV', type: 'nominal', format: 's1', alt: 'Distance To Previous Mutation (BP)' },
             { field: 'POS', type: 'genomic' },
-            { field: 'SUBTYPE', type: 'nominal' }
+            { field: 'SUBTYPE', type: 'nominal' },
+            { field: 'REF', type: 'nominal' },
+            { field: 'ALT', type: 'nominal' }
         ],
         width,
         height


### PR DESCRIPTION
This PR additionally displays REF and ALT from the point mutation tracks.