### PR TITLE
fix: clear active filters when passing null filter option

### DIFF
--- a/src/ui/VisOverviewPanel/OverviewFilter.tsx
+++ b/src/ui/VisOverviewPanel/OverviewFilter.tsx
@@ -73,6 +73,7 @@ export const OverviewFilter = ({
     const handleOptionSelection = (option: FilterOption | null) => {
         if (option === null) {
             setSelectedOption(null);
+            setActiveFilters([]); // Clear all active filters
         } else {
             setSelectedOption(option.name); // Set the selected option name
             setActiveFilters([identifier]); // Set active filter to only the current identifier


### PR DESCRIPTION
Clear active filters in overview panel when passing null filter option