### PR TITLE
avoid inconsistent LOH and Gain

### DIFF
--- a/src/track/gain.ts
+++ b/src/track/gain.ts
@@ -19,6 +19,7 @@ export default function gain(
             url: cnvUrl,
             type: 'csv',
             chromosomeField: 'chromosome',
+            sampleLength: 99999,
             genomicFields: ['start', 'end']
         },
         dataTransform: [

--- a/src/track/loh.ts
+++ b/src/track/loh.ts
@@ -19,6 +19,7 @@ export default function loh(
             url: cnvUrl,
             type: 'csv',
             chromosomeField: 'chromosome',
+            sampleLength: 99999,
             genomicFields: ['start', 'end']
         },
         dataTransform: [


### PR DESCRIPTION
This basically increases the number of data points selected after sampling for LOH and Gain tracks.

Before:
<img width="1238" height="1237" alt="Screenshot 2026-01-15 at 4 41 14 PM" src="https://github.com/user-attachments/assets/2a4a1bc8-251f-464a-ad0c-5b4c5ab1fbed" />

After:
<img width="1246" height="1244" alt="Screenshot 2026-01-15 at 4 40 54 PM" src="https://github.com/user-attachments/assets/d5cb6619-e7e7-4a3e-acf2-166c92fa1059" />
